### PR TITLE
Use process.execPath to run jasmine-node

### DIFF
--- a/main.js
+++ b/main.js
@@ -86,7 +86,7 @@ var closeFunc = Meteor.bindEnvironment(function () {
 
 var rerunTests = function () {
     deleteFolderRecursive(TEST_REPORTS_DIR);
-    var jasmineNode = spawn('/usr/local/bin/node', args);
+    var jasmineNode = spawn(process.execPath, args);
     jasmineNode.stdout.on('data', regurgitate);
     jasmineNode.stderr.on('data', regurgitate);
     jasmineNode.on('close', closeFunc);


### PR DESCRIPTION
Meteor ships with its own node binary, which should probably be used rather than `/usr/local/bin/node` (which doesn't exist on my machine because I use boxen).
